### PR TITLE
Fix value_from_datadict KeyError exception

### DIFF
--- a/cropperjs/widgets.py
+++ b/cropperjs/widgets.py
@@ -7,7 +7,7 @@ class CropperWidget(ClearableFileInput):
     template_name = "cropperjs/widgets/cropperjs.html"
 
     def value_from_datadict(self, data, files, name):
-        filedata = data[name]
+        filedata = data.get(name)
         return filedata if filedata and filedata != "" else None
 
     def format_value(self, value):


### PR DESCRIPTION
The current implementation throws a KeyError exception if the value is not present on the form data. 
I also checked the base widget implementation of the django's forms and they retrieve it the same way.